### PR TITLE
[WIP] return models after CV

### DIFF
--- a/catboost/libs/train_lib/cross_validation.cpp
+++ b/catboost/libs/train_lib/cross_validation.cpp
@@ -821,7 +821,7 @@ void CrossValidate(
 
     if (cvParams.ReturnCVModels) {
         for (const auto& foldContext : foldContexts) {
-            results->front().CVFullModels.push_back(foldContext.FullModel.Get());
+            results->front().CVFullModels.push_back(*foldContext.FullModel.Get());
         }
     }
 

--- a/catboost/libs/train_lib/cross_validation.cpp
+++ b/catboost/libs/train_lib/cross_validation.cpp
@@ -819,7 +819,7 @@ void CrossValidate(
         }
     }
 
-    if (cvParams.ReturnCVModels) {
+    if (cvParams.ReturnModels) {
         for (const auto& foldContext : foldContexts) {
             results->front().CVFullModels.push_back(*foldContext.FullModel.Get());
         }

--- a/catboost/libs/train_lib/cross_validation.cpp
+++ b/catboost/libs/train_lib/cross_validation.cpp
@@ -819,6 +819,12 @@ void CrossValidate(
         }
     }
 
+    if (cvParams.ReturnCVModels) {
+        for (const auto& foldContext : foldContexts) {
+            results->front().CVFullModels.push_back(foldContext.FullModel.Get());
+        }
+    }
+
     if (!outputFileOptions.GetRocOutputPath().empty()) {
         CB_ENSURE(
             catBoostOptions.LossFunctionDescription->GetLossFunction() == ELossFunction::Logloss,

--- a/catboost/libs/train_lib/cross_validation.h
+++ b/catboost/libs/train_lib/cross_validation.h
@@ -38,7 +38,7 @@ struct TCVResult {
     TVector<double> AverageTest;
     TVector<double> StdDevTest;
 
-    TVector<const TFullModel*> CVFullModels;
+    TVector<TFullModel> CVFullModels;
 
     //for painting
     TVector<double> LastTrainEvalMetric;//[foldIdx]

--- a/catboost/libs/train_lib/cross_validation.h
+++ b/catboost/libs/train_lib/cross_validation.h
@@ -38,6 +38,8 @@ struct TCVResult {
     TVector<double> AverageTest;
     TVector<double> StdDevTest;
 
+    TVector<const TFullModel*> CVFullModels;
+
     //for painting
     TVector<double> LastTrainEvalMetric;//[foldIdx]
     TVector<double> LastTestEvalMetric;//[foldIdx]

--- a/catboost/private/libs/options/cross_validation_params.h
+++ b/catboost/private/libs/options/cross_validation_params.h
@@ -23,6 +23,7 @@ struct TCrossValidationParams : public TSplitParams {
     ui32 DevMaxIterationsBatchSize = 100000; // useful primarily for tests
     ECrossValidation Type = ECrossValidation::Classical;
     bool IsCalledFromSearchHyperparameters = false;
+    bool ReturnCVModels = false;
 
 public:
     bool Initialized() const {

--- a/catboost/private/libs/options/cross_validation_params.h
+++ b/catboost/private/libs/options/cross_validation_params.h
@@ -23,7 +23,7 @@ struct TCrossValidationParams : public TSplitParams {
     ui32 DevMaxIterationsBatchSize = 100000; // useful primarily for tests
     ECrossValidation Type = ECrossValidation::Classical;
     bool IsCalledFromSearchHyperparameters = false;
-    bool ReturnCVModels = false;
+    bool ReturnModels = false;
 
 public:
     bool Initialized() const {

--- a/catboost/python-package/catboost/_catboost.pyx
+++ b/catboost/python-package/catboost/_catboost.pyx
@@ -5051,20 +5051,13 @@ cdef TCustomTrainTestSubsets _make_train_test_subsets(_PoolBase pool, folds) exc
     return result
 
 
-cpdef _prepare_cv_models(const TCVResult& cv_result):
-    catboost_models = []
-    for i in range(cv_result.CVFullModels.size()):
-        catboost_model = _CatBoost()
-        catboost_model.__model.Swap(<TFullModel>cv_result.CVFullModels[i])
-    return catboost_models
-
-
 cpdef _cv(dict params, _PoolBase pool, int fold_count, bool_t inverted, int partition_random_seed,
           bool_t shuffle, bool_t stratified, float metric_update_interval, bool_t as_pandas, folds, 
           type, bool_t return_cv_models):
     prep_params = _PreprocessParams(params)
     cdef TCrossValidationParams cvParams
     cdef TVector[TCVResult] results
+    cdef TVector[TFullModel] cvFullModels
 
     cvParams.FoldCount = fold_count
     cvParams.PartitionRandSeed = partition_random_seed
@@ -5122,7 +5115,12 @@ cpdef _cv(dict params, _PoolBase pool, int fold_count, bool_t inverted, int part
     else:
         results_output = cv_results
     if return_cv_models:
-        cv_models = _prepare_cv_models(results[0])
+        cv_models = []
+        cvFullModels = results.front().CVFullModels
+        for i in range(<int>cvFullModels.size()):
+            catboost_model = _CatBoost()
+            catboost_model.__model.Swap(cvFullModels[i])
+            cv_models.append(catboost_model)
         return results_output, cv_models
     return results_output
 

--- a/catboost/python-package/catboost/_catboost.pyx
+++ b/catboost/python-package/catboost/_catboost.pyx
@@ -642,6 +642,7 @@ cdef extern from "catboost/private/libs/options/cross_validation_params.h":
         double MetricUpdateInterval
         ui32 DevMaxIterationsBatchSize
         bool_t IsCalledFromSearchHyperparameters
+        bool_t ReturnCVModels
 
 cdef extern from "catboost/private/libs/options/split_params.h":
     cdef cppclass TTrainTestSplitParams:
@@ -699,6 +700,7 @@ cdef extern from "catboost/libs/train_lib/cross_validation.h":
         TVector[double] StdDevTrain
         TVector[double] AverageTest
         TVector[double] StdDevTest
+        TVector[TFullModel] CVFullModels
 
     cdef void CrossValidate(
         TJsonValue jsonParams,
@@ -5049,8 +5051,17 @@ cdef TCustomTrainTestSubsets _make_train_test_subsets(_PoolBase pool, folds) exc
     return result
 
 
+cpdef _prepare_cv_models(const TCVResult& cv_result):
+    catboost_models = []
+    for i in range(cv_result.CVFullModels.size()):
+        catboost_model = _CatBoost()
+        catboost_model.__model.Swap(<TFullModel>cv_result.CVFullModels[i])
+    return catboost_models
+
+
 cpdef _cv(dict params, _PoolBase pool, int fold_count, bool_t inverted, int partition_random_seed,
-          bool_t shuffle, bool_t stratified, float metric_update_interval, bool_t as_pandas, folds, type):
+          bool_t shuffle, bool_t stratified, float metric_update_interval, bool_t as_pandas, folds, 
+          type, bool_t return_cv_models):
     prep_params = _PreprocessParams(params)
     cdef TCrossValidationParams cvParams
     cdef TVector[TCVResult] results
@@ -5060,6 +5071,7 @@ cpdef _cv(dict params, _PoolBase pool, int fold_count, bool_t inverted, int part
     cvParams.Shuffle = shuffle
     cvParams.Stratified = stratified
     cvParams.MetricUpdateInterval = metric_update_interval
+    cvParams.ReturnCVModels = return_cv_models
 
     if type == 'Classical':
         cvParams.Type = ECrossValidation_Classical
@@ -5106,8 +5118,13 @@ cpdef _cv(dict params, _PoolBase pool, int fold_count, bool_t inverted, int part
         )
         result_metrics.add(name)
     if as_pandas:
-        return pd.DataFrame.from_dict(cv_results)
-    return cv_results
+        results_output = pd.DataFrame.from_dict(cv_results)
+    else:
+        results_output = cv_results
+    if return_cv_models:
+        cv_models = _prepare_cv_models(results[0])
+        return results_output, cv_models
+    return results_output
 
 
 cdef _convert_to_visible_labels(EPredictionType predictionType, TVector[TVector[double]] raws, int thread_count, TFullModel* model):

--- a/catboost/python-package/catboost/_catboost.pyx
+++ b/catboost/python-package/catboost/_catboost.pyx
@@ -642,7 +642,7 @@ cdef extern from "catboost/private/libs/options/cross_validation_params.h":
         double MetricUpdateInterval
         ui32 DevMaxIterationsBatchSize
         bool_t IsCalledFromSearchHyperparameters
-        bool_t ReturnCVModels
+        bool_t ReturnModels
 
 cdef extern from "catboost/private/libs/options/split_params.h":
     cdef cppclass TTrainTestSplitParams:
@@ -5053,7 +5053,7 @@ cdef TCustomTrainTestSubsets _make_train_test_subsets(_PoolBase pool, folds) exc
 
 cpdef _cv(dict params, _PoolBase pool, int fold_count, bool_t inverted, int partition_random_seed,
           bool_t shuffle, bool_t stratified, float metric_update_interval, bool_t as_pandas, folds, 
-          type, bool_t return_cv_models):
+          type, bool_t return_models):
     prep_params = _PreprocessParams(params)
     cdef TCrossValidationParams cvParams
     cdef TVector[TCVResult] results
@@ -5064,7 +5064,7 @@ cpdef _cv(dict params, _PoolBase pool, int fold_count, bool_t inverted, int part
     cvParams.Shuffle = shuffle
     cvParams.Stratified = stratified
     cvParams.MetricUpdateInterval = metric_update_interval
-    cvParams.ReturnCVModels = return_cv_models
+    cvParams.ReturnModels = return_models
 
     if type == 'Classical':
         cvParams.Type = ECrossValidation_Classical
@@ -5114,7 +5114,7 @@ cpdef _cv(dict params, _PoolBase pool, int fold_count, bool_t inverted, int part
         results_output = pd.DataFrame.from_dict(cv_results)
     else:
         results_output = cv_results
-    if return_cv_models:
+    if return_models:
         cv_models = []
         cvFullModels = results.front().CVFullModels
         for i in range(<int>cvFullModels.size()):

--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -5390,6 +5390,19 @@ def train(pool=None, params=None, dtrain=None, logging_level=None, verbose=None,
     return model
 
 
+def _convert_to_catboost(models):
+    """
+    Convert _Catboost instances to Catboost ones 
+    """
+    output_models = []
+    for model in models:
+        cb_model = CatBoost()
+        cb_model._object = model
+        cb_model._set_trained_model_attributes()
+        output_models.append(cb_model)
+    return output_models
+
+
 def cv(pool=None, params=None, dtrain=None, iterations=None, num_boost_round=None,
        fold_count=None, nfold=None, inverted=False, partition_random_seed=0, seed=None,
        shuffle=True, logging_level=None, stratified=None, as_pandas=True, metric_period=None,
@@ -5610,8 +5623,14 @@ def cv(pool=None, params=None, dtrain=None, iterations=None, num_boost_round=Non
         raise CatBoostError("Cv with embedding features is not implemented.")
 
     with log_fixup(), plot_wrapper(plot, [_get_train_dir(params)]):
-        return _cv(params, pool, fold_count, inverted, partition_random_seed, shuffle, stratified,
-                   metric_update_interval, as_pandas, folds, type, return_models)
+        if not return_models:
+            return _cv(params, pool, fold_count, inverted, partition_random_seed, shuffle, stratified,
+                    metric_update_interval, as_pandas, folds, type, return_models)
+        else:
+            results, cv_models = _cv(params, pool, fold_count, inverted, partition_random_seed, shuffle, stratified,
+                                     metric_update_interval, as_pandas, folds, type, return_models)
+            output_cv_models = _convert_to_catboost(cv_models)
+            return results, output_cv_models
 
 
 class BatchMetricCalcer(_MetricCalcerBase):

--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -5394,7 +5394,8 @@ def cv(pool=None, params=None, dtrain=None, iterations=None, num_boost_round=Non
        fold_count=None, nfold=None, inverted=False, partition_random_seed=0, seed=None,
        shuffle=True, logging_level=None, stratified=None, as_pandas=True, metric_period=None,
        verbose=None, verbose_eval=None, plot=False, early_stopping_rounds=None,
-       save_snapshot=None, snapshot_file=None, snapshot_interval=None, metric_update_interval=0.5, folds=None, type='Classical'):
+       save_snapshot=None, snapshot_file=None, snapshot_interval=None, metric_update_interval=0.5, 
+       folds=None, type='Classical', return_cv_models=False):
     """
     Cross-validate the CatBoost model.
 
@@ -5607,7 +5608,7 @@ def cv(pool=None, params=None, dtrain=None, iterations=None, num_boost_round=Non
 
     with log_fixup(), plot_wrapper(plot, [_get_train_dir(params)]):
         return _cv(params, pool, fold_count, inverted, partition_random_seed, shuffle, stratified,
-                   metric_update_interval, as_pandas, folds, type)
+                   metric_update_interval, as_pandas, folds, type, return_cv_models)
 
 
 class BatchMetricCalcer(_MetricCalcerBase):

--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -5520,6 +5520,7 @@ def cv(pool=None, params=None, dtrain=None, iterations=None, num_boost_round=Non
     -------
     cv results : pandas.core.frame.DataFrame with cross-validation results
         columns are: test-error-mean  test-error-std  train-error-mean  train-error-std
+    cv models : list of trained models, if return_models=True
     """
     if params is None:
         raise CatBoostError("params should be set.")

--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -5395,7 +5395,7 @@ def cv(pool=None, params=None, dtrain=None, iterations=None, num_boost_round=Non
        shuffle=True, logging_level=None, stratified=None, as_pandas=True, metric_period=None,
        verbose=None, verbose_eval=None, plot=False, early_stopping_rounds=None,
        save_snapshot=None, snapshot_file=None, snapshot_interval=None, metric_update_interval=0.5, 
-       folds=None, type='Classical', return_cv_models=False):
+       folds=None, type='Classical', return_models=False):
     """
     Cross-validate the CatBoost model.
 
@@ -5499,6 +5499,9 @@ def cv(pool=None, params=None, dtrain=None, iterations=None, num_boost_round=Non
         (https://scikit-learn.org/stable/modules/classes.html#splitter-classes)
         and have ``split`` method.
         if folds is not None, then all of fold_count, shuffle, partition_random_seed, inverted are None
+
+    return_models: bool, optional (default=False)
+        if True, return a list of fitted models from each CV fold
 
     Returns
     -------
@@ -5608,7 +5611,7 @@ def cv(pool=None, params=None, dtrain=None, iterations=None, num_boost_round=Non
 
     with log_fixup(), plot_wrapper(plot, [_get_train_dir(params)]):
         return _cv(params, pool, fold_count, inverted, partition_random_seed, shuffle, stratified,
-                   metric_update_interval, as_pandas, folds, type, return_cv_models)
+                   metric_update_interval, as_pandas, folds, type, return_models)
 
 
 class BatchMetricCalcer(_MetricCalcerBase):

--- a/catboost/python-package/catboost/core.py
+++ b/catboost/python-package/catboost/core.py
@@ -5514,7 +5514,7 @@ def cv(pool=None, params=None, dtrain=None, iterations=None, num_boost_round=Non
         if folds is not None, then all of fold_count, shuffle, partition_random_seed, inverted are None
 
     return_models: bool, optional (default=False)
-        if True, return a list of fitted models from each CV fold
+        if True, return a list of models fitted for each CV fold
 
     Returns
     -------

--- a/catboost/python-package/ut/medium/test.py
+++ b/catboost/python-package/ut/medium/test.py
@@ -2964,6 +2964,19 @@ def test_cv_return_models(task_type):
         cv_model_roc_auc = eval_metric(test_pool.get_label(), model_prediction, 'AUC')[0]
         assert np.allclose(cv_model_roc_auc, single_model_roc_auc, atol=results["test-AUC-std"][0])
 
+        # Other methods
+        model.calc_leaf_indexes(test_pool)
+        try:
+            model.compare(single_model, test_pool, ["AUC"])
+        except ImportError as ie:
+            pytest.xfail(str(ie)) if str(ie) == "No module named widget" \
+                else pytest.fail(str(ie))
+        assert model.get_all_params().keys() == single_model.get_all_params().keys()
+        assert not np.isna(model.get_feature_importance(test_pool)).any()
+        assert not np.isna(model.get_scale_and_bias()).any()
+        new_model = model.copy()
+        del model
+
 
 def test_cv_small_data():
     cv_data = [["France", 1924, 44],

--- a/catboost/python-package/ut/medium/test.py
+++ b/catboost/python-package/ut/medium/test.py
@@ -2947,7 +2947,7 @@ def test_cv_return_models(task_type):
         fold_count=fold_count,
         return_models=True,
     )
-    
+
     assert len(cv_models) == fold_count
 
     single_model = CatBoost(model_params).fit(train_pool)
@@ -2974,7 +2974,7 @@ def test_cv_return_models(task_type):
         assert model.get_all_params().keys() == single_model.get_all_params().keys()
         assert not np.isna(model.get_feature_importance(test_pool)).any()
         assert not np.isna(model.get_scale_and_bias()).any()
-        new_model = model.copy()
+        model.copy()
         del model
 
 


### PR DESCRIPTION
This PR addresses the following issue: https://github.com/catboost/catboost/issues/1524

TODO list:
- [x] Allow adding tuned models to the CV results in CPP
- [x] Support this behaviour in Cython and Python
- [x] Write tests for saving CV models